### PR TITLE
Bumped version to 0.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cbor",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "homepage": "https://github.com/paroga/cbor-js",
   "authors": [
     "Patrick Gansterer <paroga@paroga.com>"


### PR DESCRIPTION
Because cbor-js is already at version `0.1.0` (https://github.com/paroga/cbor-js/commit/fc0429055945a6f458ab9c127f8fcf625298974b) it makes sense to update this value also in the `bower.json` file. Otherwise bower is angry when executing `bower install cbor`:

```
bower cbor#* mismatch Version declared in the json (0.0.0) is different than the resolved one (0.1.0)
```