### PR TITLE
Replace DataView.getUint8 by typed array access

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -185,6 +185,7 @@ function encode(value) {
 
 function decode(data, tagger, simpleValue) {
   var dataView = new DataView(data);
+  var ta = new Uint8Array(data);
   var offset = 0;
   
   if (typeof tagger !== "function")
@@ -225,7 +226,7 @@ function decode(data, tagger, simpleValue) {
     return read(dataView.getFloat64(offset), 8);
   }
   function readUint8() {
-    return read(dataView.getUint8(offset), 1);
+    return read(ta[offset], 1);
   }
   function readUint16() {
     return read(dataView.getUint16(offset), 2);
@@ -237,7 +238,7 @@ function decode(data, tagger, simpleValue) {
     return readUint32() * POW_2_32 + readUint32();
   }
   function readBreak() {
-    if (dataView.getUint8(offset) !== 0xff)
+    if (ta[offset] !== 0xff)
       return false;
     offset += 1;
     return true;


### PR DESCRIPTION
Using DataView is currently still slower than directly accessing a typed array. For the case of the expression `dataView.getUint8(offset)` it is possible to circumvent the use of DataView and directly use a typed array. This is possible since the DataView is initialized with a 1 byte element length, which makes it equivalent to a direct Uint8Array view of the data.

With this change, there are speed increases of 15% on Chrome 47 and 36% on Firefox 42 on my machine while decoding around 200MiB of data. Testing was done with a very large array of numbers where one third of elements were nulls.

I am working with such big data, so I would be happy if this is merged. Typically the data I have compresses extremely well (60MiB get down to 2MiB after gzipping in my case) so the bottleneck is the CBOR decoding after the data is unzipped. And this change is one step in making cbor-js a bit faster.

Test code:

``` js
var data = new Array(1024*1024*25) //*8 ~ 200MiB
for (var i=0; i<data.length; i++) {
  data[i] = i % 3 === 0 ? null : i + 0.1
}
var obj = {
  data: data
}  
var cborData = CBOR.encode(obj)

var runs = 3
var t0 = new Date()
for (var i=0; i<runs; i++) {
  CBOR.decode(cborData)
}
console.log((new Date()-t0)/runs + 'ms')
```
