### PR TITLE
Support nodejs (module.exports)

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -398,6 +398,8 @@ var obj = { encode: encode, decode: decode };
 
 if (typeof define === "function" && define.amd)
   define("cbor/cbor", obj);
+else if (typeof module !== 'undefined' && module.exports)
+  module.exports = obj;
 else if (!global.CBOR)
   global.CBOR = obj;
 


### PR DESCRIPTION
This is needed to use cbor-js within node.js. See also #5

The code is taken from another fork: https://github.com/tn2-solutions/cbor-js/commit/6e4761f708c0d3888f37d3b2b298fef4a6c9fc98