### PR TITLE
npm publish

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -398,6 +398,8 @@ var obj = { encode: encode, decode: decode };
 
 if (typeof define === "function" && define.amd)
   define("cbor/cbor", obj);
+else if (typeof module !== 'undefined' && module.exports)
+  module.exports = obj;
 else if (!global.CBOR)
   global.CBOR = obj;
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cbor",
+  "name": "cbor-js",
   "version": "0.1.0",
   "description": "The Concise Binary Object Representation (CBOR) data format (RFC7049) implemented in pure JavaScript.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "author": "Patrick Gansterer <paroga@paroga.com> (http://paroga.com/)",
   "main": "cbor.js",
+  "files": [
+    "cbor.js"
+  ],
   "repository": {
     "type": "git",
     "url": "http://github.com/paroga/cbor-js.git"


### PR DESCRIPTION
These are changes required for npm publishing. The name "cbor" exists on npm already, so I renamed the "name" string in package.json to "cbor-js". I already did a test publish at https://www.npmjs.com/package/cbor-js and used it successfully in my project. I added you as collaborator on npm for that package.

Please first merge #9, then this pull request.