### PR TITLE
float 16 & 32 encoding, string encoding, allowRemainingBytes option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 cbor-js.zip
 cbor.min.js
 sauce_connect.log
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 cbor-js.zip
 cbor.min.js
 sauce_connect.log
+/temp
 /.idea

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <codeStyleSettings language="JavaScript">
+          <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="2" />
+            <option name="TAB_SIZE" value="2" />
+          </indentOptions>
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,9 +120,9 @@ module.exports = function(grunt) {
             src: srcFiles,
             instrumentedFiles: "temp/",
             lcovReport: covDirectory,
-            branchesThresholdPct: 95,
+            branchesThresholdPct: 100,
             functionsThresholdPct: 100,
-            linesThresholdPct: 95
+            linesThresholdPct: 100
           }
         }
       }


### PR DESCRIPTION
~~switched from runtime allocation strategy to exact accounting allocation strategy
this removes some growth penalties, slicing, and buffer copies at the expense of iterating over the object being encoded twice (not sure if performance impact is beneficial, need to make benchmarks)~~

~~some methods have been renamed to reflect their intention~~

~~I plan to change (and rename) appendUtf16Data to append chars to string instead of using String.fromCharCode.apply ; this strategy has improved performance in many other scenarios, but not sure of impact here~~

~~I plan to add a small benchmark suite to the tests~~

~~code coverage needs to be improved, some methods need to be removed, some branches need to be refined~~

~~forked from another fork to pull a string-to-integer key change~~

~~messed with the tests, added one, changed the forEach to a for loop (to access loop counter, but then did not use yet...) and lots of commented out console.log and console.error statements~~

~~*allowRemainingBytes option not yet tested, default false~~

rebasing and reducing scope of changes