### PR TITLE
change to string enc and dec, float 16 and 32 encoding, tweaks, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 cbor-js.zip
 cbor.min.js
 sauce_connect.log
+/.idea


### PR DESCRIPTION
add .idea to .gitignore
add options parameter to decode
add automatic encoding for float16 and float32
separate function for writeUtf8String
decode returns undefined for empty data buffer
readFloat16 uses decodeFloat16, introduced to separate read from checking validity of encoding
appendUtf16Data uses string instead of array during encoding
switch(majorType) uses default: instead of case 0:, since majorType can only be 0-7, improves branch performance
add option for allowRemainingBytes during decoding
update tests to account for float16 and float32 encodings
add tests for additional scenarios
added some /* istanbul ignore if */ statements for specific feature-test scenarios