### PR TITLE
Deprecated Bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "cbor",
-  "version": "0.1.1",
   "homepage": "https://github.com/paroga/cbor-js",
   "authors": [
     "Patrick Gansterer <paroga@paroga.com>"


### PR DESCRIPTION
The `version` attribute of Bower is deprecated: https://github.com/bower/spec/blob/master/json.md#version

Bower is using the versions listed on:
- https://github.com/paroga/cbor-js/releases
