### PR TITLE
Fixed call stack problems when decoding large strings

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -25,7 +25,8 @@
 (function(global, undefined) { "use strict";
 var POW_2_24 = 5.960464477539063e-8,
     POW_2_32 = 4294967296,
-    POW_2_53 = 9007199254740992;
+    POW_2_53 = 9007199254740992,
+    DECODE_CHUNK_SIZE = 8192;
 
 function encode(value) {
   var data = new ArrayBuffer(256);
@@ -350,7 +351,14 @@ function decode(data, tagger, simpleValue) {
             appendUtf16Data(utf16data, length);
         } else
           appendUtf16Data(utf16data, length);
-        return String.fromCharCode.apply(null, utf16data);
+        var string = "";
+        for (i = 0; i < utf16data.length; i += DECODE_CHUNK_SIZE) {
+          string += String.fromCharCode.apply(
+            null,
+            utf16data.slice(i, i + DECODE_CHUNK_SIZE)
+          );
+        }
+        return string;
       case 4:
         var retArray;
         if (length < 0) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,7 +5,7 @@ var testcases = function(undefined) {
     for (var i = 0; i < data.length; ++i) {
       uintArray[i] = data[i];
     }
-    return new Uint8Array(data);  
+    return new Uint8Array(data);
   }
 
   return [
@@ -433,6 +433,13 @@ test("Big Array", function() {
   deepEqual(CBOR.decode(CBOR.encode(value)), value, 'deepEqual')
 });
 
+test("Big String", function() {
+  var value = ''
+  for (var i = 0; i < 150000; ++i)
+    value += Math.floor(i % 10).toString()
+  deepEqual(CBOR.decode(CBOR.encode(value)), value, 'deepEqual')
+});
+
 test("Remaining Bytes", function() {
   var threw = false;
   try {
@@ -504,7 +511,7 @@ test("Tagging", function() {
   }, function(value) {
     return new SimpleValue(value);
   });
-  
+
   ok(decoded[0] instanceof TaggedValue, "first item is a TaggedValue");
   equal(decoded[0].value, 3, "first item value");
   equal(decoded[0].tag, 0x12, "first item tag");


### PR DESCRIPTION
This PR fixes errors that are thrown when decoding large strings. Such errors look like:

```
RangeError: Maximum call stack size exceeded
    at decodeItem (/path/to/cbor-js/cbor.js:370:28)
    at decodeItem (/path/to/cbor-js/cbor.js:370:28)
    at decodeItem (/path/to/cbor-js/cbor.js:370:28)
    at decodeItem (/path/to/cbor-js/cbor.js:363:27)
    at decode (/path/to/cbor-js/cbor.js:391:13)
    at ...
```

The errors are being thrown because calling `String.fromCharCode.apply` with a very large array translates to calling `String.fromCharCode` with a huge number of arguments, which can quickly exceed the maximum stack size. To get around this, I've broken the calls to `String.fromCharCode.apply` into chunks of 8192 values at a time.

I've included a test which I *think* should demonstrate the problem, but unfortunately I couldn't get the tests running on my machine. The exact size of string required to trigger the error probably depends on the runtime environment, but I can tell you that I experienced this problem in both browsers and Node.JS with strings of around 300KB in size.