### PR TITLE
Optimize byte array encoding

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -30,6 +30,7 @@ var POW_2_24 = 5.960464477539063e-8,
 function encode(value) {
   var data = new ArrayBuffer(256);
   var dataView = new DataView(data);
+  var byteView = new Uint8Array(data);
   var lastLength;
   var offset = 0;
 
@@ -42,6 +43,7 @@ function encode(value) {
       var oldDataView = dataView;
       data = new ArrayBuffer(newByteLength);
       dataView = new DataView(data);
+      byteView = new Uint8Array(data);
       var uint32count = (offset + 3) >> 2;
       for (var i = 0; i < uint32count; ++i)
         dataView.setUint32(i << 2, oldDataView.getUint32(i << 2));
@@ -60,9 +62,8 @@ function encode(value) {
     commitWrite(prepareWrite(1).setUint8(offset, value));
   }
   function writeUint8Array(value) {
-    var dataView = prepareWrite(value.length);
-    for (var i = 0; i < value.length; ++i)
-      dataView.setUint8(offset + i, value[i]);
+    prepareWrite(value.length);
+    byteView.set(value, offset);
     commitWrite();
   }
   function writeUint16(value) {


### PR DESCRIPTION
Copy the entire byte array instead of iterating over one byte at a time.  This makes CBOR much much faster at encoding messages with large binary blobs.

Benchmarking on this data, a ROS2 sensor_msgs/Image of 640x480 RGB:

```
var benchmarkData = {
  header: {
    stamp: {
      sec: 1,
      nanosec: 1e8
    },
    frame_id: ""
  },
  height: 480,
  width: 640,
  encoding: "RGB",
  is_bigendian: 0,
  step: 640,
  data: Uint8Array.from(Array.from({length: 640 * 480 * 3}, () => 128))
};
```

### master

`CBOR encode: 20.234ms`

### fast_byte_array_encoding
`CBOR encode: 1.288ms`