### PR TITLE
Fix handling of codepoints >= 0xe000

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -129,7 +129,7 @@ function encode(value) {
           } else if (charCode < 0x800) {
             utf8data.push(0xc0 | charCode >> 6);
             utf8data.push(0x80 | charCode & 0x3f);
-          } else if (charCode < 0xd800) {
+          } else if (charCode < 0xd800 || charCode >= 0xe000) {
             utf8data.push(0xe0 | charCode >> 12);
             utf8data.push(0x80 | (charCode >> 6)  & 0x3f);
             utf8data.push(0x80 | charCode & 0x3f);


### PR DESCRIPTION
Codepoints in [U+E000,U+FFFF] were incorrectly handled by the surrogate pair code path.

Example of behavior before the fix:
```
duk> CBOR.encode('\ue000')
= |64f0908080|
duk> CBOR.decode(CBOR.encode('\ue000'))
= "\ud800\udc00"
duk> CBOR.decode(CBOR.encode('\uffff'))
= "\udbff\udc00"
```

After the fix:
```
duk> CBOR.encode('\ue000')
= |63ee8080|
duk> CBOR.decode(CBOR.encode('\ue000'))
= "\ue000"
duk> CBOR.decode(CBOR.encode('\uffff'))
= "\uffff"
```

Cbor.me gives the following for encoding `"\ue000"`, matching the fixed output:
```
63        # text(3)
   EE8080 # "\xEE\x80\x80"
```